### PR TITLE
Bug when using Select as value was converted into a string

### DIFF
--- a/floppyforms/widgets.py
+++ b/floppyforms/widgets.py
@@ -114,7 +114,7 @@ class Input(Widget):
 
         if value != '':
             # Only add the value if it is non-empty
-            context['value'] = self.format_value(value)
+            context['value'] = self._format_value(value)
 
         context.update(self.get_context_data())
         context['attrs'] = self.build_attrs(attrs)


### PR DESCRIPTION
For some reason the get_context method of the Input class of the widgets.py was calling format_value instead of _format_value.